### PR TITLE
Update acme-color-theme.json

### DIFF
--- a/themes/acme-color-theme.json
+++ b/themes/acme-color-theme.json
@@ -45,5 +45,8 @@
 		"tab.hoverBackground": "#eeee9e",
 		"tab.hoverBorder": "#eaffff",
 		"tab.inactiveForeground": "#000",
+		"list.focusHighlightForeground": "#eaffff",
+                "quickInputList.focusForeground": "#eaffff",
+                "editorSuggestWidget.selectedForeground": "#eaffff",
 	}
 }


### PR DESCRIPTION
VSCode now offers 3 new color tokens.  Without setting them, the results would be hard to read in quick open dropdown menu etc.